### PR TITLE
Use context names only when clusterid is not available

### DIFF
--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -185,8 +185,6 @@ func getGatewayIP(clusterInfo *cluster.Info, localClusterID string, status repor
 func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, namespace string, options FirewallOptions,
 	status reporter.Interface, targetPort TargetPort, message string,
 ) error {
-	mustHaveSubmariner(localClusterInfo)
-	mustHaveSubmariner(remoteClusterInfo)
 
 	status.Start(message)
 	defer status.End()
@@ -246,7 +244,7 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, names
 
 	gatewayPodIP, err := getGatewayIP(remoteClusterInfo, localClusterInfo.Submariner.Status.ClusterID, status)
 	if err != nil {
-		return status.Error(err, "Error retrieving the gateway IP of cluster %q", localClusterInfo.Name)
+		return status.Error(err, "Error retrieving the gateway IP of cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 	}
 
 	podCommand = fmt.Sprintf("for x in $(seq 1000); do echo %s; done | for i in $(seq 5);"+
@@ -257,7 +255,8 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, names
 	cPod, err := spawnClientPodOnNonGatewayNodeWithHostNet(remoteClusterInfo.ClientProducer.ForKubernetes(), namespace,
 		podCommand, localClusterInfo.GetImageRepositoryInfo())
 	if err != nil {
-		return status.Error(err, "Error spawning the client pod on non-Gateway node of cluster %q", remoteClusterInfo.Name)
+		return status.Error(err, "Error spawning the client pod on non-Gateway node of cluster %q",
+			remoteClusterInfo.Submariner.Status.ClusterID)
 	}
 
 	defer cPod.Delete()

--- a/pkg/diagnose/firewall_natdiscovery.go
+++ b/pkg/diagnose/firewall_natdiscovery.go
@@ -28,13 +28,16 @@ import (
 func NatDiscoveryConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, namespace string, options FirewallOptions,
 	status reporter.Interface,
 ) error {
-	message := fmt.Sprintf("Checking if nat-discovery port is opened on the gateway node of cluster %q", localClusterInfo.Name)
+	mustHaveSubmariner(localClusterInfo)
+	mustHaveSubmariner(remoteClusterInfo)
+
+	message := fmt.Sprintf("Checking if nat-discovery port is opened on the gateway node of cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 
 	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, namespace, options, status, NatDiscoveryPort, message)
 	if err != nil {
-		status.Failure("Could not determine if nat-discovery port is allowed in the cluster %q", localClusterInfo.Name)
+		status.Failure("Could not determine if nat-discovery port is allowed in the cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 	} else {
-		status.Success("nat-discovery port is allowed in the cluster %q", localClusterInfo.Name)
+		status.Success("nat-discovery port is allowed in the cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 	}
 
 	return err

--- a/pkg/diagnose/firewall_tunnel.go
+++ b/pkg/diagnose/firewall_tunnel.go
@@ -28,13 +28,16 @@ import (
 func TunnelConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, namespace string, options FirewallOptions,
 	status reporter.Interface,
 ) error {
-	message := fmt.Sprintf("Checking if tunnels can be setup on the gateway node of cluster %q", localClusterInfo.Name)
+	mustHaveSubmariner(localClusterInfo)
+	mustHaveSubmariner(remoteClusterInfo)
+
+	message := fmt.Sprintf("Checking if tunnels can be setup on the gateway node of cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 
 	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, namespace, options, status, TunnelPort, message)
 	if err != nil {
-		status.Failure("Could not determine if Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Name)
+		status.Failure("Could not determine if Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 	} else {
-		status.Success("Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Name)
+		status.Success("Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Submariner.Status.ClusterID)
 	}
 
 	return err


### PR DESCRIPTION
For all subctl commands, all status and printfs should print clusterid used while joining the cluster via --clusterID flag. In case the flag is not specified, print clustername from kubeconfig.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
